### PR TITLE
GH rename & file path fix  [semver:patch]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # CircleCI Utils
 
 
-[![CircleCI Build Status](https://circleci.com/gh/kr-project/circleci-utils.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/kr-project/circleci-utils) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/coda/utils)](https://circleci.com/orbs/registry/orb/coda/utils) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/kr-project/circleci-utils/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
+[![CircleCI Build Status](https://circleci.com/gh/coda-hq/circleci-utils.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/coda-hq/circleci-utils) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/coda/utils)](https://circleci.com/orbs/registry/orb/coda/utils) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/coda-hq/circleci-utils/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
 [Example Usage](src/examples/example.yml)
 ### How to Publish
@@ -43,4 +43,4 @@ Individually testing for each command is done in `config.yml`.
 ## Used in Following Repos:
 - infra
 - headless-chrome
-- experimental
+- coda

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -8,4 +8,4 @@ description: >
   - Cancel older CI alerts waiting for approval 
 
 display:
-  source_url: "https://github.com/kr-project/circleci-utils"
+  source_url: "https://github.com/coda-hq/circleci-utils"

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -121,6 +121,6 @@ steps:
     - run:
         command: |
           cat /tmp/raw-webhook.json | jq '.details.outcome="failed"'  > /tmp/webhook.json
-          curl -X POST -H"Content-Type:application/json" -H "Authorization: GenieKey ${OPS_GENIE_API_KEY}" -d @/tmp/webhook.json https://api.opsgenie.com/v2/alerts
+          curl -X POST -H"Content-Type:application/json" -H "Authorization: GenieKey ${OPS_GENIE_API_KEY}" -d @/tmp/raw-webhook.json https://api.opsgenie.com/v2/alerts
         name: Notify $<<parameters.endpoint>> with Failure Webhook
         when: on_fail

--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -130,7 +130,7 @@ steps:
     - run:
         command: |
           cat /tmp/raw-webhook.json | jq '.details.outcome="failed"'  > /tmp/webhook.json
-          mv /tmp/webhook_temp.json /tmp/raw-webhook.json
+          mv /tmp/webhook.json /tmp/raw-webhook.json
           curl -X POST -H"Content-Type:application/json" -H "Authorization: GenieKey ${OPS_GENIE_API_KEY}" -d @/tmp/raw-webhook.json https://api.opsgenie.com/v2/alerts
         name: Notify $<<parameters.endpoint>> with Failure Webhook
         when: on_fail

--- a/src/scripts/fetch_user_handles.sh
+++ b/src/scripts/fetch_user_handles.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 USER_EMAIL=""
 SLACK_USER_ID=""
 # TO DO; change w/ github migration
-GITHUB_API="https://api.github.com/repos/kr-project/${CIRCLE_PROJECT_REPONAME}"
+GITHUB_API="https://api.github.com/repos/coda-hq/${CIRCLE_PROJECT_REPONAME}"
 function run_main() {
     # fetch all user information from coda doc based on users CircleCI username
     TABLE_INFO=$(curl -s -H "Authorization: Bearer ${CODA_PROD_TOKEN}" \


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

Github naming migration -> moving from `kr-project` to `coda-hq` and `experimental` to `coda` 
See details here: https://staging.coda.io/d/Github-Rename-Migration_dZRtl44sES_/Github-Renames_suNid#_lu0cY