### PR TITLE
github user account rename [semver:minor] 

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -1,26 +1,5 @@
 description: Send build results to Opsgenie API, with detailed information
 parameters:
-  coda_user_roster_table_url:
-    description: |
-      Fully qualified API URL to a table containing CIRCLECI_USERNAMEs to email aliases.    Must be of the form
-      https://coda.io/apis/v1/docs/<DOCID>/tables/<TABLEID>/rows.
-    type: string
-    default: https://coda.io/apis/v1/docs/CBRzjlr8md/tables/table-37x7Jsfrqx/rows
-  coda_circleci_user_name_col:
-    description: |
-      Coda columnId of the column storing the CircleCI username in the coda_user_roster_table_url document.
-    type: string
-    default: c-HWxgJukgCs
-  coda_github_col:
-    description: |
-      Coda columnId of the column storing the full name in the coda_user_roster_table_url document.
-    type: string
-    default: c-HWxgJukgCs
-  coda_user_email_col:
-    description: |
-      Coda columnId of the column storing the Coda email in the coda_user_roster_table_url document.
-    type: string
-    default: c-l3XSvkG3vB
   endpoint:
     default: OPSGENIE_WEBHOOK
     description: Enter either your Full URL value that you copied in Opsgenie
@@ -34,33 +13,16 @@ parameters:
     default: true
     description: Success information of circleci build
     type: boolean
-  coda_prod_token:
-    default: $CODA_PROD_TOKEN
-    description: |
-      Env var of a token granted read access to the coda_user_roster_table_url document.
-    type: string
   email_domain:
     description: |
       Optional email domain for users within the workspace.   Must be specified if user aliases are not fully qualified.
     type: string
     default: coda.io
-  circle_token:
-    default: $CIRCLECI_TOKEN
-    description: |
-      Env var of a token granted read access to the CircleCI api
-    type: string
 steps:
 - run:
     name: Set variables
-    when: always
     command: |
-      echo "export CODA_PROD_TOKEN=<<parameters.coda_prod_token>>" >> "$BASH_ENV"
-      echo "export CIRCLECI_TOKEN=<<parameters.circle_token>>" >> "$BASH_ENV"
       echo "export EMAIL_DOMAIN=<<parameters.email_domain>>" >> "$BASH_ENV"
-      echo "export CODA_CIRCLECI_USER_NAME_COL=<<parameters.coda_circleci_user_name_col>>" >> "$BASH_ENV"
-      echo "export CODA_USER_EMAIL_COL=<<parameters.coda_user_email_col>>" >> $BASH_ENV
-      echo "export CODA_GITHUB_COL=<<parameters.coda_github_col>>" >> $BASH_ENV
-      echo "export CODA_USER_ROSTER_TABLE_URL=<<parameters.coda_user_roster_table_url>>" >> "$BASH_ENV"
 - run:
     name: Fetch User Information
     when: on_fail

--- a/src/commands/slack-notify-waiting-for-approval.yml
+++ b/src/commands/slack-notify-waiting-for-approval.yml
@@ -49,12 +49,7 @@ steps:
 - run:
     name: Set variables
     command: |
-      echo "export CODA_PROD_TOKEN=<<parameters.coda_prod_token>>" >> "$BASH_ENV"
       echo "export EMAIL_DOMAIN=<<parameters.email_domain>>" >> "$BASH_ENV"
-      echo "export CODA_CIRCLECI_USER_NAME_COL=<<parameters.coda_circleci_user_name_col>>" >> "$BASH_ENV"
-      echo "export CODA_GITHUB_COL=<<parameters.coda_github_col>>" >> "$BASH_ENV"
-      echo "export CODA_USER_EMAIL_COL=<<parameters.coda_user_email_col>>" >> "$BASH_ENV"
-      echo "export CODA_USER_ROSTER_TABLE_URL=<<parameters.coda_user_roster_table_url>>" >> "$BASH_ENV"
       echo "export SLACK_BOT_TOKEN=<<parameters.slack_bot_token>>" >> "$BASH_ENV"
 - run:
     name: Fetch User Information from Look Up Table

--- a/src/jobs/slack-notify-waiting-for-approval.yml
+++ b/src/jobs/slack-notify-waiting-for-approval.yml
@@ -3,38 +3,10 @@ description: |
   Depends on jq being present.
 
   Setup:
-    1. Create Coda document with a table containing columns `circleci alias` (ex: github username) and `email`, and populate this table with information for each github user.
-    3. Find the docId, tableId, and columnIds for the circleci user alias and email columnIds.
-    4. Create a Coda API token for this document at https://coda.io/account - limit the token to read access to the target table.
-    5. Setup a Slack Bot account with scopes `users:read`, `users:read.email`, and `chat:write`.
-    6. Configure orb based on required args
+    1. Ensure github user has format <email-prefix>-codaio 
+    2. Setup a Slack Bot account with scopes `users:read`, `users:read.email`, and `chat:write`.
+    3. Configure orb based on required args
 parameters:
-  coda_user_roster_table_url:
-    description: |
-      Fully qualified API URL to a table containing CIRCLECI_USERNAME to email aliases.    Must be of the form
-      https://coda.io/apis/v1/docs/<DOCID>/tables/<TABLEID>/rows.
-    type: string
-    default: https://coda.io/apis/v1/docs/CBRzjlr8md/tables/table-37x7Jsfrqx/rows
-  coda_prod_token:
-    description: |
-      Env var of a token granted read access to the coda_user_roster_table_url document.
-    type: string
-    default: $CODA_PROD_TOKEN
-  coda_circleci_user_name_col:
-    description: |
-      Coda columnId of the column storing the CircelCI username (typically github alias).
-    type: string
-    default: c-HWxgJukgCs
-  coda_github_col:
-    description: |
-      Coda columnId of the column storing the full name in the coda_user_roster_table_url document.
-    type: string
-    default: c-HWxgJukgCs
-  coda_user_email_col:
-    description: |
-      Coda columnId of the column storing the Coda email in the coda_user_roster_table_url document.
-    type: string
-    default: c-l3XSvkG3vB
   email_domain:
     description: |
       Optional email domain for users within the workspace.   Must be specified if user aliases are not fully qualified.
@@ -45,14 +17,8 @@ parameters:
     type: string
     description: |
       Token used by Slack bot application.   Must have scopes `users:read`, `users:read.email`, and `chat:write`.
-
 executor: default
 steps:
   - slack-notify-waiting-for-approval:
-      coda_prod_token: <<parameters.coda_prod_token>>
-      coda_circleci_user_name_col: <<parameters.coda_circleci_user_name_col>>
-      coda_user_email_col: <<parameters.coda_user_email_col>>
-      coda_github_col: <<parameters.coda_github_col>>
-      coda_user_roster_table_url: <<parameters.coda_user_roster_table_url>>
       email_domain: <<parameters.email_domain>>
       slack_bot_token: <<parameters.slack_bot_token>>

--- a/src/scripts/fetch_user_handles.sh
+++ b/src/scripts/fetch_user_handles.sh
@@ -2,75 +2,22 @@
 set -eo pipefail
 USER_EMAIL=""
 SLACK_USER_ID=""
+GITHUB_SUFFIX="-codaio"
 # TO DO; change w/ github migration
-GITHUB_API="https://api.github.com/repos/coda-hq/${CIRCLE_PROJECT_REPONAME}"
 function run_main() {
-    # fetch all user information from coda doc based on users CircleCI username
-    TABLE_INFO=$(curl -s -H "Authorization: Bearer ${CODA_PROD_TOKEN}" \
-      -G --data-urlencode "query=${CODA_CIRCLECI_USER_NAME_COL}:\"${CIRCLE_USERNAME}\"" \
-      "${CODA_USER_ROSTER_TABLE_URL}")
-    if [ -z "$TABLE_INFO" ]; then
-      echo "${CIRCLE_USERNAME} username does not exist in go/roster; please add it in"
-      exit 1
+    if [[ "$CIRCLE_USERNAME" != *"$GITHUB_SUFFIX"* ]]; then
+      echo "${CIRCLE_USERNAME} has incorrect git username -- please add -codaio and update in go/roster"
+      exit 0
     fi
-    # parse email from coda table
-    USER_EMAIL=$(echo "$TABLE_INFO" | \
-      jq -r --arg CODA_USER_EMAIL_COL "$CODA_USER_EMAIL_COL" \
-      '.items[0].values."'"$CODA_USER_EMAIL_COL"'"' )
-
-    # if CircleCI username returned no email (ex; bot) get author of last git commit
-    if [ "$USER_EMAIL" == "null" ]; then
-
-        #get pull requests from pr
-        GITHUB_PRS_FROM_COMMIT=$(curl -s "${GITHUB_API}/commits/${CIRCLE_SHA1}/pulls" \
-          -H "Accept: application/vnd.github.groot-preview+json" \
-          -H "Authorization: Bearer ${GITHUB_TOKEN}")
-
-        # get first pr number from list pull requests
-        GITHUB_PR_NUMBER=$(echo "$GITHUB_PRS_FROM_COMMIT" | tr '\r\n' ' ' | jq '.[0].number')
-        # get associated information from that pr
-        GITHUB_GET_PR=$(curl -s "${GITHUB_API}/pulls/${GITHUB_PR_NUMBER}" \
-        -H "Authorization: Bearer ${GITHUB_TOKEN}")
-        # get the author of that pr
-        PR_AUTHOR=$(echo "$GITHUB_GET_PR" | jq -r '.user.login' )
-        # if it is not a bot then set it as the look up user from table
-        if [[ "$PR_AUTHOR" != *"[bot]"* ]]; then
-          LOOKUP_USER=$PR_AUTHOR
-        else #else get the reviewer of that pr
-
-          GITHUB_GET_PR_REVIEWERS=$(curl -s "${GITHUB_API}/pulls/${GITHUB_PR_NUMBER}/reviews" \
-          -H "Authorization: token ${GITHUB_TOKEN}" |  tr -d " \t\n\r" )
-
-          # and get the first reviewer of that pr that approved pr
-          for row in $(echo "$GITHUB_GET_PR_REVIEWERS" | jq -c '.[]'); do
-              STATE=$(echo "$row" | jq '.state' )
-              if [[ "$STATE" == *"APPROVED"* ]]; then
-                  LOOKUP_USER=$(echo "$row" | jq -r '.user.login' )
-                  break
-              fi
-          done
-        fi
-
-        # look up email of Codan using Author name from github
-        TABLE_INFO=$(curl -s -H "Authorization: Bearer ${CODA_PROD_TOKEN}" \
-          -G --data-urlencode "query=${CODA_GITHUB_COL}:\"${LOOKUP_USER}\"" \
-          "${CODA_USER_ROSTER_TABLE_URL}")
-
-        # look up the email from that Codan
-        USER_EMAIL=$(echo "$TABLE_INFO" | \
-        jq -r --arg CODA_USER_EMAIL_COL "$CODA_USER_EMAIL_COL" \
-        '.items[0].values."'"$CODA_USER_EMAIL_COL"'"' )
-        # potentially null if dependabot
-        if [ "$USER_EMAIL" == "null" ]; then
-            USER_EMAIL=""
-        fi
-    fi
+     # shellcheck disable=SC2001
+    USER_EMAIL=$(echo "${CIRCLE_USERNAME}" | sed "s/${GITHUB_SUFFIX}$/@${EMAIL_DOMAIN}/")
 
     if [ -n "$SLACK_BOT_TOKEN" ]; then
         SLACK_USER_ID=$(curl -s -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             "https://slack.com/api/users.lookupByEmail?email=${USER_EMAIL}" \
             | jq -r '.user.id')
     fi
+    
     # need to echo result for bats test to capture
     echo "$USER_EMAIL"
     echo "$SLACK_USER_ID"

--- a/src/tests/test_user_handles.bats
+++ b/src/tests/test_user_handles.bats
@@ -6,36 +6,22 @@ setup() {
 
 @test '2: Check Coda Email Exists' {
     export CIRCLE_USERNAME="gita-codaio"
-    export CODA_PROD_TOKEN=$CODA_PROD_TOKEN
-    export CODA_CIRCLECI_USER_NAME_COL="c-HWxgJukgCs"
-    export CODA_USER_EMAIL_COL="c-l3XSvkG3vB"
-    export CODA_GITHUB_COL="c-HWxgJukgCs"
-    export CODA_USER_ROSTER_TABLE_URL="https://coda.io/apis/v1/docs/CBRzjlr8md/tables/table-37x7Jsfrqx/rows"
+    export EMAIL_DOMAIN="coda.io"
     result=$(run_main)
     [[ "$result" == *"gita@coda.io"* ]]
 }
 
 @test '3: Check Coda Email DNE' {
     export CIRCLE_USERNAME="nonexistant_user"
-    export CODA_PROD_TOKEN=$CODA_PROD_TOKEN
-    export CODA_CIRCLECI_USER_NAME_COL="c-HWxgJukgCs"
-    export CODA_USER_EMAIL_COL="c-l3XSvkG3vB"
-    export CODA_GITHUB_COL="c-HWxgJukgCs"
-    export CODA_USER_ROSTER_TABLE_URL="https://coda.io/apis/v1/docs/CBRzjlr8md/tables/table-37x7Jsfrqx/rows"
+    export EMAIL_DOMAIN="coda.io"
     result=$(run_main)
-    [[ "$result" != "coda@io" ]]
-
+    [[ "$result" != "@coda.io" ]]
 }
 
 @test '4: Check Codas Slack Handle Exists' {
     export CIRCLE_USERNAME="gita-codaio"
-    export CODA_PROD_TOKEN=$CODA_PROD_TOKEN
-    export CODA_CIRCLECI_USER_NAME_COL="c-HWxgJukgCs"
-    export CODA_USER_EMAIL_COL="c-l3XSvkG3vB"
-    export CODA_GITHUB_COL="c-HWxgJukgCs"
-    export CODA_USER_ROSTER_TABLE_URL="https://coda.io/apis/v1/docs/CBRzjlr8md/tables/table-37x7Jsfrqx/rows"
+    export EMAIL_DOMAIN="coda.io"
     export SLACK_BOT_TOKEN=$PUSH_REMINDER_BOT_TOKEN
     result=$(run_main)
     [[ "$result" == *"U01DJE1DABE"* ]]
-
 }


### PR DESCRIPTION
**do not merge until gh user account rename is done**

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

As per https://staging.coda.io/d/Coda-IT_duJQjFQTuF9/Github-User-Account-Rename_sutCP#_lupmO : change logic in fetching username from go/roster to emailprefix-codaio
